### PR TITLE
Ensure precondition run before extractor

### DIFF
--- a/lib/qo/branches/branch.rb
+++ b/lib/qo/branches/branch.rb
@@ -182,7 +182,7 @@ module Qo
 
           # Otherwise we check the precondition first before extracting the
           # value from whatever container it might be in.
-          return UNMATCHED unless @precondition === value
+          next UNMATCHED unless @precondition === value
           
           extracted_value = @extractor.call(value)
           

--- a/lib/qo/branches/branch.rb
+++ b/lib/qo/branches/branch.rb
@@ -180,11 +180,17 @@ module Qo
             next [true, destructurer.call(extracted_value)]
           end
 
-          if @precondition === value && conditions === (extracted_value = @extractor.call(value))
-            [true, destructurer.call(extracted_value)]
-          else
+          # Otherwise we check the precondition first before extracting the
+          # value from whatever container it might be in.
+          return UNMATCHED unless @precondition === value
+          
+          extracted_value = @extractor.call(value)
+          
+          # If that extracted value matches our conditions, destructure the value
+          # and return it, or return unmatched otherwise.
+          conditions === extracted_value ?
+            [true, destructurer.call(extracted_value)] :
             UNMATCHED
-          end
         }
       end
     end

--- a/lib/qo/branches/branch.rb
+++ b/lib/qo/branches/branch.rb
@@ -30,7 +30,7 @@ module Qo
     # A branch will execute in the following order:
     #
     # ```
-    # value -> precondition ? -> condition ? -> extractor -> destructurer
+    # value -> precondition ? -> extractor -> condition ? -> destructurer
     # ```
     #
     # Preconditions allow for things like type checks or any static condition
@@ -174,12 +174,13 @@ module Qo
         )
 
         Proc.new { |value|
-          extracted_value = @extractor.call(value)
-
           # If it's a default branch, return true, as conditions are redundant
-          next [true, destructurer.call(extracted_value)] if @default
+          if @default
+            extracted_value = @extractor.call(value)
+            next [true, destructurer.call(extracted_value)]
+          end
 
-          if @precondition === value && conditions === extracted_value
+          if @precondition === value && conditions === (extracted_value = @extractor.call(value))
             [true, destructurer.call(extracted_value)]
           else
             UNMATCHED

--- a/spec/branches/branch_spec.rb
+++ b/spec/branches/branch_spec.rb
@@ -17,6 +17,42 @@ RSpec.describe Qo::Branches::Branch do
     )
   }
 
+  context 'ordered' do
+    it do
+      collaborator_1 = ->(x) { true }
+      collaborator_2 = ->(x) {}
+
+      expect(collaborator_1).to receive(:===).and_return(true).ordered
+      expect(collaborator_2).to receive(:call).ordered
+
+      subject = proc do |x|
+        if collaborator_1 === x
+          collaborator_2.call(x)
+        end
+      end
+
+      subject.call()
+    end
+  end
+
+  context 'order of execution' do
+    let(:callback) { Qo::IDENTITY }
+    let(:condition) { Any }
+
+    let(:matcher) { branch.create_matcher(condition, &callback) }
+
+    let(:precondition) { ->(_) {} }
+    let(:extractor) { ->(_) {} }
+
+    it 'precondition -> extractor -> condition' do
+      expect(precondition).to receive(:===).and_return(true).ordered
+      expect(extractor).to receive(:call).ordered
+      expect(condition).to receive(:===).ordered
+
+      matcher.call(42)
+    end
+  end
+
   describe '.initialize' do
     it 'can be initialized' do
       expect(branch).to be_a(Qo::Branches::Branch)


### PR DESCRIPTION
I'm implementing matcher for Option monad and noticed that extractor called before precondition

```ruby
    SomeBranch = Qo.create_branch(
      name: 'some',
      precondition: ->(v) { v.is_a?(Fear::Some) },
      extractor: :get,
    )

    NoneBranch = Qo.create_branch(
      name: 'none',
      precondition: ->(v) { v.is_a?(Fear::None) },
    )

    OptionPatternMatch = Qo.create_pattern_match(branches: [
      SomeBranch,
      NoneBranch,
    ])
```

but getting error when matching agains None because it call `#get` method on None and ignores my precondition.

```ruby
      None().match do |m|
        m.some { |x| x * 2 }
        m.none { puts 'errr' }
      end #=> raise  Fear::NoSuchElementError
```

