### PR TITLE
Document Qo::PatternMatchers::PatternMatch#default as private API

### DIFF
--- a/lib/qo/branches/branch.rb
+++ b/lib/qo/branches/branch.rb
@@ -175,7 +175,7 @@ module Qo
 
         Proc.new { |value|
           # If it's a default branch, return true, as conditions are redundant
-          if @default
+          if default?
             extracted_value = @extractor.call(value)
             next [true, destructurer.call(extracted_value)]
           end
@@ -183,9 +183,9 @@ module Qo
           # Otherwise we check the precondition first before extracting the
           # value from whatever container it might be in.
           next UNMATCHED unless @precondition === value
-          
+
           extracted_value = @extractor.call(value)
-          
+
           # If that extracted value matches our conditions, destructure the value
           # and return it, or return unmatched otherwise.
           conditions === extracted_value ?

--- a/lib/qo/pattern_matchers/branching.rb
+++ b/lib/qo/pattern_matchers/branching.rb
@@ -40,7 +40,7 @@ module Qo
             )
 
             if branch.default?
-              @default = branch_matcher
+              self.default = branch_matcher
             else
               @matchers << branch_matcher
             end


### PR DESCRIPTION
I want my Option matcher raise error if nothing matcher instead of returning `nil` (because the whole point of having Option is to avoid dealing with nils. 

I managed to achieve this by [redefining `@default` ivar](https://github.com/bolshakov/fear/pull/21/files#diff-c15be15f8f07c35cb6dfea7168ef38f3) but not really happy with using undocumented internals:

```ruby
  module ExhaustivePatternMatch
    def initialize(**)
      super
      @default ||= self.else { fail MatchError }
    end
  end
```

So, I documented `PatternMatch#default` accessor as private API to make it valid extension point.