### PR TITLE
Remove redundant else branch from HTTP_Matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -687,8 +687,7 @@ Now if we wanted to add more power and create an HTTP matcher:
 ```ruby
 HTTP_Matcher = Qo.create_pattern_match(branches: [
   Qo.create_branch(name: 'success', precondition: Net::HTTPSuccess),
-  Qo.create_branch(name: 'error', precondition: Net::HTTPError),
-  Qo::Braches::ElseBranch
+  Qo.create_branch(name: 'error', precondition: Net::HTTPError)
 ])
 
 def get_url(url)


### PR DESCRIPTION
```ruby
HTTP_Matcher = Qo.create_pattern_match(branches: [
  Qo.create_branch(name: 'success', precondition: Net::HTTPSuccess),
  Qo.create_branch(name: 'error', precondition: Net::HTTPError),
  Qo::Braches::ElseBranch
])
```

actually you don't have to include else branch to branches, since it's already included here https://github.com/baweaver/qo/blob/master/lib/qo/pattern_matchers/pattern_match.rb#L14